### PR TITLE
Add --flowOverride option in exec command

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,15 +124,16 @@ usage: eboshi removeSchedule [-h] --url URL --username USERNAME --password
 eboshi removeSchedule: error: argument --url is required
 ```
 ```
-eboshi removeSchedule --url http://localhost:8081 --username azkaban --password azkaban scheduleId 1
+eboshi removeSchedule --url http://localhost:8081 --username azkaban --password azkaban --scheduleId 1
 ```
 
 * exec azkaban job flow
 ```
 $ eboshi exec
 usage: eboshi exec [-h] --url URL --username USERNAME --password PASSWORD
-                   --project PROJECT --flow FLOW [--disabled DISABLED]
-                   [--successEmails SUCCESSEMAILS]
+                   --project PROJECT --flow FLOW
+                   [--flowOverride [FLOWOVERRIDE [FLOWOVERRIDE ...]]]
+                   [--disabled DISABLED] [--successEmails SUCCESSEMAILS]
                    [--failureEmails FAILUREEMAILS]
                    [--successEmailsOverride SUCCESSEMAILSOVERRIDE]
                    [--failureEmailsOverride FAILUREEMAILSOVERRIDE]
@@ -143,5 +144,5 @@ usage: eboshi exec [-h] --url URL --username USERNAME --password PASSWORD
 eboshi exec: error: argument --url is required
 ```
 ```
-eboshi exec --url http://localhost:8081 --username azkaban --password azkaban --project azkaban_project --flow azkaban_flow --disabled '["aaa","bbb"]'
+eboshi exec --url http://localhost:8081 --username azkaban --password azkaban --project azkaban_project --flow azkaban_flow --flowOverride k1=v1 k2=v2 --disabled '["aaa","bbb"]'
 ```

--- a/eboshi/exec.py
+++ b/eboshi/exec.py
@@ -22,6 +22,7 @@ class Exec(Command):
         parser.add_argument('--password', required=True)
         parser.add_argument('--project', required=True)
         parser.add_argument('--flow', required=True)
+        parser.add_argument('--flowOverride', nargs='*', default=[])
         parser.add_argument('--disabled')
         parser.add_argument('--successEmails')
         parser.add_argument('--failureEmails')
@@ -54,6 +55,11 @@ class Exec(Command):
         params["notifyFailureLast"] = parsed_args.notifyFailureLast
         params["failureAction"] = parsed_args.failureAction
         params["concurrentOption"] = parsed_args.concurrentOption
+
+        for item in parsed_args.flowOverride:
+            pair = item.split("=")
+            params["flowOverride[%s]" % pair[0]] = pair[1]
+
         r = requests.get(url + "/executor", params=params)
         jc = r.json()
         if jc.get("execid") is None:


### PR DESCRIPTION
Hi,

This PR add a new option named `--flowOverride` for customizing flow parameters in exec. Although the option is not documented, it works correctly in Azkaban 2.5.

https://github.com/azkaban/azkaban/blob/master/azkaban-common/src/main/java/azkaban/server/HttpRequestUtils.java#L100

Sample is like this:

```
$ eboshi --log-file log exec --url http://localhost:8081 --username user --password pass --project test --flow eboshi --flowOverride dt=2015-04-01 hh=00
```
