### PR TITLE
Change scheduleid to scheduleId

### DIFF
--- a/eboshi/list_schedules.py
+++ b/eboshi/list_schedules.py
@@ -28,11 +28,10 @@ class List_Schedules(Command):
         items = schedule.list_schedules()
         for item in items:
             flowname = item["flowname"]
-            scheduleid = item["scheduleid"]
+            scheduleId = item["scheduleId"]
             projectname = item["projectname"]
             cron = item.get("cron", "")
             period = item["period"]
             time = item["time"]
             history = item["history"]
-            print "flowname:%s, scheduleid:%s, projectname:%s, cron:%s, period:%s, time:%s, history:%s" % (flowname, scheduleid, projectname, cron, period, time, history)
-
+            print "flowname:%s, scheduleId:%s, projectname:%s, cron:%s, period:%s, time:%s, history:%s" % (flowname, scheduleId, projectname, cron, period, time, history)

--- a/eboshi/schedule.py
+++ b/eboshi/schedule.py
@@ -19,7 +19,7 @@ class Schedule:
         params["session.id"] = session_id
         r = requests.get(self.url + "/schedule", params=params)
         jc = r.json()
-        return jc.get("items", [])
+        return jc.get("items", []) 
 
     def remove_schedule(self, scheduleId):
         session = Session(self.url, self.username, self.password)
@@ -51,4 +51,4 @@ class Schedule:
         params["flowId"] = flow
         r = requests.get(self.url + "/schedule", params=params)
         jc = r.json()
-        return jc.get("schedule")
+        return jc.get("schedule") 

--- a/eboshi/schedule.py
+++ b/eboshi/schedule.py
@@ -19,7 +19,7 @@ class Schedule:
         params["session.id"] = session_id
         r = requests.get(self.url + "/schedule", params=params)
         jc = r.json()
-        return jc.get("items", []) 
+        return jc.get("items", [])
 
     def remove_schedule(self, scheduleId):
         session = Session(self.url, self.username, self.password)
@@ -37,8 +37,8 @@ class Schedule:
     def remove_all_schedules(self):
         items = self.list_schedules()
         for item in items:
-            scheduleid = item["scheduleid"]
-            self.remove_schedule(scheduleid)
+            scheduleId = item["scheduleId"]
+            self.remove_schedule(scheduleId)
 
     def get_schedule(self, project, flow):
         session = Session(self.url, self.username, self.password)
@@ -51,4 +51,4 @@ class Schedule:
         params["flowId"] = flow
         r = requests.get(self.url + "/schedule", params=params)
         jc = r.json()
-        return jc.get("schedule") 
+        return jc.get("schedule")


### PR DESCRIPTION
This PR is a correction that accompanies the format change of the response data of Azkaban API.

Due to changes in https://github.com/azkaban/azkaban/pull/2121, the Azkaban API response returns scheduleId instead of scheduleid in 3.71.0 and later versions.